### PR TITLE
Shallow search for model parts

### DIFF
--- a/src/pysdf/parse.py
+++ b/src/pysdf/parse.py
@@ -201,7 +201,7 @@ class World(object):
     self.version = kwargs.get('version', self.version)
     if node.findall('world'):
       node = node.findall('world')[0]
-      for include_node in node.iter('include'):
+      for include_node in node.findall('include'):
         included_model = model_from_include(None, include_node)
         if not included_model:
           print('Failed to include model, see previous errors. Aborting.')
@@ -344,10 +344,10 @@ class Model(SpatialEntity):
       return
     self.version = kwargs.get('version', self.version)
     super(Model, self).from_tree(node, **kwargs)
-    self.links = [Link(self, tree=link_node) for link_node in node.iter('link')]
-    self.joints = [Joint(self, tree=joint_node) for joint_node in node.iter('joint')]
+    self.links = [Link(self, tree=link_node) for link_node in node.findall('link')]
+    self.joints = [Joint(self, tree=joint_node) for joint_node in node.findall('joint')]
 
-    for include_node in node.iter('include'):
+    for include_node in node.findall('include'):
       included_submodel = model_from_include(self, include_node)
       if not included_submodel:
         print('Failed to include model, see previous errors. Aborting.')
@@ -556,8 +556,8 @@ class Link(SpatialEntity):
       return
     super(Link, self).from_tree(node)
     self.inertial = Inertial(tree=get_node(node, 'inertial'))
-    self.collisions = [Collision(tree=collision_node) for collision_node in node.iter('collision')]
-    self.visuals = [Visual(tree=visual_node) for visual_node in node.iter('visual')]
+    self.collisions = [Collision(tree=collision_node) for collision_node in node.findall('collision')]
+    self.visuals = [Visual(tree=visual_node) for visual_node in node.findall('visual')]
 
   def is_empty(self):
     return len(self.visuals) == 0 and len(self.collisions) == 0


### PR DESCRIPTION
Hi, I've stumbled upon a problem where pysdf would crash when I'd add ros_bumper plugin to my model. The reason was that, ros_bumper uses `<collision>` tag to set which collision it should be watching. While I think it is not good to reuse SDF/URDF tags for a different purposes in plugins, it does happen sometimes.

I managed to fix that issue by replacing all occurences of node.iter to node.findall in pysdf's `parse.py` file. I think it makes sense since, for instance SDF's specification allows `<collision>` tags to be only direct descendants of `<link>`, therefore there's no use in searching through the entire sub-tree of a link to find collisions.
I hope it makes sense. Here's a pull request.
