### PR TITLE
allow file uri prefix, and not only model uri prefix

### DIFF
--- a/src/pysdf/parse.py
+++ b/src/pysdf/parse.py
@@ -135,8 +135,13 @@ def indent(string, spaces):
 
 def model_from_include(parent, include_node):
     submodel_uri = get_tag(include_node, 'uri')
-    submodel_uri = submodel_uri.replace('model://', '')
-    submodel_path = find_model_in_gazebo_dir(submodel_uri)
+    # check if submodel_uri has model on it or file
+    if submodel_uri[:5] == 'model':
+        submodel_uri = submodel_uri.replace('model://', '')
+        submodel_path = find_model_in_gazebo_dir(submodel_uri)
+    elif submodel_uri[:4] == 'file':
+        submodel_uri = submodel_uri.replace('file://', '')
+        submodel_path = find_model_in_gazebo_dir(submodel_uri)
     if not submodel_path:
       print('Failed to find included model (URI: %s)' % submodel_uri)
       return


### PR DESCRIPTION
Extend code to allow not only this:
```
    <include>
        <uri>model://ground_plane</uri>
    </include>
```
but also this:
```
    <include>
        <uri>file://foo_folder/bar_model</uri>
    </include>
```